### PR TITLE
Avoid merging sequential articles via NEXT_ID in NCSE parser

### DIFF
--- a/ncse_olive_to_meili.py
+++ b/ncse_olive_to_meili.py
@@ -336,13 +336,18 @@ def collect_articles(issue_dir: Path):
 
 def build_chains(articles: dict):
     """
-    Build continuation chains using CONTINUATION_TO (preferred) or NEXT_ID.
+    Build continuation chains using CONTINUATION_TO links.
+
+    NEXT_ID in the Olive data simply points to the next article in the
+    issue and does not imply continuation. Including it in the chain
+    logic incorrectly merged consecutive articles. We therefore rely
+    solely on explicit CONTINUATION_TO links.
     Returns list of chains (each is list[ArID]) preserving order.
     """
     next_map = {}
     prev_targets = set()
     for arid, a in articles.items():
-        nxt = a["links"].get("CONTINUATION_TO") or a["links"].get("NEXT_ID")
+        nxt = a["links"].get("CONTINUATION_TO")
         if nxt:
             next_map[arid] = nxt
             prev_targets.add(nxt)


### PR DESCRIPTION
## Summary
- avoid using `NEXT_ID` for article chaining in `ncse_olive_to_meili.py`
- rely solely on `CONTINUATION_TO` links to prevent unrelated articles from merging

## Testing
- `python -m py_compile ncse_olive_to_meili.py`
- `python3 ncse_olive_to_meili.py . -o out_new.jsonl --chunk-size 2200`


------
https://chatgpt.com/codex/tasks/task_e_68a0f3cd77d4832985b0b80af7021119